### PR TITLE
fix(auth): force callback redirects to configured app base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ DATABASE_URL_UNPOOLED=postgresql://user:pass@host.neon.tech/wikismith?sslmode=re
 WORKOS_API_KEY=
 WORKOS_CLIENT_ID=
 WORKOS_COOKIE_PASSWORD=
+# Base URL used by callback handler after auth code exchange.
+# Local: http://localhost:3000
+# Production: https://wikismith.dudkin-garage.com
+APP_BASE_URL=http://localhost:3000
 WORKOS_REDIRECT_URI=http://localhost:3000/api/auth/callback
 # Keep NEXT_PUBLIC_WORKOS_REDIRECT_URI in sync with WORKOS_REDIRECT_URI.
 NEXT_PUBLIC_WORKOS_REDIRECT_URI=http://localhost:3000/api/auth/callback

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -4,7 +4,9 @@ import { syncAuthenticatedUser } from '@/lib/auth/user-store';
 
 export const dynamic = 'force-dynamic';
 
+const callbackBaseUrl = process.env['APP_BASE_URL'];
 export const GET = handleAuth({
+  baseURL: callbackBaseUrl,
   returnPathname: '/dashboard',
   onSuccess: async ({ user, oauthTokens }) => {
     await syncAuthenticatedUser(


### PR DESCRIPTION
## Summary
- add `APP_BASE_URL` to env config so auth callback redirects are host-stable across local and production
- pass `baseURL` into WorkOS `handleAuth` callback route to avoid host/header inference sending localhost sign-ins to production
- document local/prod values in `.env.example`

## Verification
- pnpm --filter @wikismith/web type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force auth callback redirects to the app’s base URL to prevent cross-host redirects between local and production. Adds APP_BASE_URL and passes it to WorkOS handleAuth.

- **Migration**
  - Set APP_BASE_URL in all environments (local: http://localhost:3000, production: https://wikismith.dudkin-garage.com).
  - Redeploy after setting the variable.

<sup>Written for commit 57e8f652dc95a53022919d3b5fc6c13964d0746f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

