### PR TITLE
chore(repo): add opencode ClickUp MCP config

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "clickup": {
+      "type": "remote",
+      "url": "https://mcp.clickup.com/mcp",
+      "oauth": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `opencode.json` at the repository root to register the remote ClickUp MCP endpoint for OpenCode.
- Configuration only includes schema URL and MCP endpoint metadata; OAuth block is empty and contains no credentials.

## Notes
- No secrets or tokens were added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opencode.json to register the remote ClickUp MCP endpoint for OpenCode. The config includes the schema URL and endpoint metadata; the OAuth block is empty (no secrets).

<sup>Written for commit 4285cf778918b6dcb5712e471ea662b8faf1545a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

