### PR TITLE
feat(skills): add clickup ticket implementer workflow

### DIFF
--- a/.agents/skills/clickup-ticket-implementer
+++ b/.agents/skills/clickup-ticket-implementer
@@ -1,0 +1,1 @@
+../../skills/clickup-ticket-implementer

--- a/.cursor/rules/clickup-ticket-implementer.md
+++ b/.cursor/rules/clickup-ticket-implementer.md
@@ -1,0 +1,1 @@
+../../skills/clickup-ticket-implementer/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,17 @@
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-----------|
-| **Monorepo** | Turborepo + pnpm |
-| **Web App** | Next.js 16 (App Router) |
-| **Styling** | Tailwind CSS + shadcn/ui |
-| **Database** | Neon PostgreSQL + pgvector |
-| **ORM** | Drizzle ORM + Drizzle Kit |
-| **Auth** | WorkOS (GitHub OAuth social connection) |
-| **AI** | OpenAI SDK (gpt-5-mini + text-embedding-3-small) |
-| **Testing** | Vitest + Playwright |
-| **Deployment** | Vercel |
+| Layer          | Technology                                       |
+| -------------- | ------------------------------------------------ |
+| **Monorepo**   | Turborepo + pnpm                                 |
+| **Web App**    | Next.js 16 (App Router)                          |
+| **Styling**    | Tailwind CSS + shadcn/ui                         |
+| **Database**   | Neon PostgreSQL + pgvector                       |
+| **ORM**        | Drizzle ORM + Drizzle Kit                        |
+| **Auth**       | WorkOS (GitHub OAuth social connection)          |
+| **AI**         | OpenAI SDK (gpt-5-mini + text-embedding-3-small) |
+| **Testing**    | Vitest + Playwright                              |
+| **Deployment** | Vercel                                           |
 
 ## Repository Structure
 
@@ -44,14 +44,19 @@ wikismith/
 
 The project is a monorepo managed by **pnpm** and **Turborepo**.
 
-| Command | What it does |
-|---------|-------------|
-| `pnpm install` | Install all workspace packages |
-| `pnpm dev` | Start development servers for all apps |
-| `pnpm build` | Build all packages and apps |
-| `pnpm lint` | Run ESLint + Prettier across the repo |
-| `pnpm test` | Run Vitest across all workspaces |
+| Command           | What it does                               |
+| ----------------- | ------------------------------------------ |
+| `pnpm install`    | Install all workspace packages             |
+| `pnpm dev`        | Start development servers for all apps     |
+| `pnpm build`      | Build all packages and apps                |
+| `pnpm lint`       | Run ESLint + Prettier across the repo      |
+| `pnpm test`       | Run Vitest across all workspaces           |
 | `pnpm type-check` | TypeScript type-checking on all workspaces |
+
+### Optional Local Review Tool
+
+- `cubic review` is used in some agent workflows for local AI review.
+- `cubic` is not a workspace dependency; install it globally on the machine and ensure it is available in `PATH` before using skills that require it.
 
 ### Running a Single Test File
 
@@ -75,13 +80,13 @@ pnpm test --filter @wikismith/analyzer
 
 ### 2.2 Naming Conventions
 
-| Category | Rule |
-|----------|------|
+| Category              | Rule                                         |
+| --------------------- | -------------------------------------------- |
 | Variables / constants | `camelCase`, `UPPER_SNAKE_CASE` for env vars |
-| Functions | `camelCase`, descriptive names |
-| React components | `PascalCase`, filename matches component |
-| Types / interfaces | `PascalCase`, prefix interfaces with `I` |
-| Enums | `PascalCase` with constant values |
+| Functions             | `camelCase`, descriptive names               |
+| React components      | `PascalCase`, filename matches component     |
+| Types / interfaces    | `PascalCase`, prefix interfaces with `I`     |
+| Enums                 | `PascalCase` with constant values            |
 
 ### 2.3 Formatting
 
@@ -118,10 +123,10 @@ All implementation tasks are tracked in ClickUp. **Every agent must use ClickUp 
 
 The ClickUp space uses two statuses:
 
-| Status | Meaning |
-|--------|---------|
-| `to do` | Not started — available for pickup |
-| `complete` | Done — acceptance criteria met |
+| Status     | Meaning                            |
+| ---------- | ---------------------------------- |
+| `to do`    | Not started — available for pickup |
+| `complete` | Done — acceptance criteria met     |
 
 > **No "in progress" status exists.** When starting a task, add a comment via `clickup_create_task_comment` stating you are working on it. Set `complete` when done.
 
@@ -137,14 +142,14 @@ WikiSmith (folder)
 
 ### Remaining Tickets (pick from here)
 
-| Task ID | Task Name | Phase | Status | Dependencies |
-|---------|-----------|-------|--------|-------------|
-| `86c8ez71x` | CI/CD Pipeline & Vercel Deployment Baseline | 0 | `to do` | Scaffold ✅ |
-| `86c8ez7tz` | Authentication & Authorization (WorkOS + GitHub OAuth) | 2 | `to do` | DB Schema ✅ |
-| `86c8ez7xk` | Repository Management Dashboard | 2 | `to do` | Auth |
-| `86c8ez82a` | Embeddings Pipeline & RAG Infrastructure | 3 | `to do` | Generation ✅, DB ✅ |
-| `86c8ez851` | Q&A System (RAG + Streaming) | 3 | `to do` | Embeddings, Auth |
-| `86c8ez87w` | Wiki Versioning & Auto-Update (Webhooks) | 3 | `to do` | Generation ✅, Auth |
+| Task ID     | Task Name                                              | Phase | Status  | Dependencies         |
+| ----------- | ------------------------------------------------------ | ----- | ------- | -------------------- |
+| `86c8ez71x` | CI/CD Pipeline & Vercel Deployment Baseline            | 0     | `to do` | Scaffold ✅          |
+| `86c8ez7tz` | Authentication & Authorization (WorkOS + GitHub OAuth) | 2     | `to do` | DB Schema ✅         |
+| `86c8ez7xk` | Repository Management Dashboard                        | 2     | `to do` | Auth                 |
+| `86c8ez82a` | Embeddings Pipeline & RAG Infrastructure               | 3     | `to do` | Generation ✅, DB ✅ |
+| `86c8ez851` | Q&A System (RAG + Streaming)                           | 3     | `to do` | Embeddings, Auth     |
+| `86c8ez87w` | Wiki Versioning & Auto-Update (Webhooks)               | 3     | `to do` | Generation ✅, Auth  |
 
 Tasks with all dependencies marked ✅ are **ready for pickup now**.
 
@@ -196,13 +201,14 @@ Phase 3 — Advanced (⬜ partially ready):
 
 Skills are defined in `skills/` and symlinked to `.cursor/rules/` (Cursor) and `.agents/skills/` (OpenCode).
 
-| Agent | Skill File | Purpose |
-|-------|-----------|---------|
-| PRD Writer | `skills/prd-writer/SKILL.md` | Writes feature PRDs |
-| Test Architect | `skills/test-architect/SKILL.md` | Designs test strategies and specs |
-| Code Reviewer | `skills/code-reviewer/SKILL.md` | Reviews code quality and patterns |
-| Architecture | `skills/architecture/SKILL.md` | Makes and documents architecture decisions |
-| UI/UX | `skills/ui-ux/SKILL.md` | Designs and reviews UI components |
+| Agent                      | Skill File                                   | Purpose                                                           |
+| -------------------------- | -------------------------------------------- | ----------------------------------------------------------------- |
+| PRD Writer                 | `skills/prd-writer/SKILL.md`                 | Writes feature PRDs                                               |
+| Test Architect             | `skills/test-architect/SKILL.md`             | Designs test strategies and specs                                 |
+| Code Reviewer              | `skills/code-reviewer/SKILL.md`              | Reviews code quality and patterns                                 |
+| Architecture               | `skills/architecture/SKILL.md`               | Makes and documents architecture decisions                        |
+| UI/UX                      | `skills/ui-ux/SKILL.md`                      | Designs and reviews UI components                                 |
+| ClickUp Ticket Implementer | `skills/clickup-ticket-implementer/SKILL.md` | Executes ClickUp tickets end-to-end, including PR/CI/review loops |
 
 ## 6. Feature PRD Conventions
 

--- a/skills/clickup-ticket-implementer/SKILL.md
+++ b/skills/clickup-ticket-implementer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clickup-ticket-implementer
-description: Implement a ClickUp ticket end-to-end for WikiSmith: read ticket and PRD, implement with tests, run/fix local cubic review until clean, create PR, iterate on CI and review comments until clean, and close out ClickUp after merge.
+description: Implement a ClickUp ticket end-to-end for WikiSmith: read ticket and PRD, implement with tests, run/fix local cubic review until clean (with global cubic CLI), create PR, iterate on CI and review comments until clean, and close out ClickUp after merge.
 ---
 
 # ClickUp Ticket Implementer
@@ -30,8 +30,8 @@ You execute a WikiSmith ClickUp ticket from intake to merge-ready completion wit
    - Treat PRD requirements as source of truth unless the ticket explicitly overrides them.
 
 4. **Set task to active state**
-   - Attempt to set status to `in progress` when that status exists in the list/workspace.
-   - If `in progress` does not exist (WikiSmith commonly uses `to do` and `complete` only), add a start comment using `clickup_create_task_comment` explaining work has started and on which branch.
+   - WikiSmith default workflow: add a start comment using `clickup_create_task_comment` explaining work has started and on which branch.
+   - Only set `in progress` when the specific ClickUp list explicitly supports that status.
 
 5. **Implement the ticket completely**
    - Create a branch using repo naming conventions (`feat/...`, `fix/...`, etc.).
@@ -41,6 +41,7 @@ You execute a WikiSmith ClickUp ticket from intake to merge-ready completion wit
 
 6. **Local quality loop (must be clean before PR)**
    - Run relevant lint, type-check, and tests.
+   - Ensure `cubic` CLI is installed globally and available in `PATH` before running review.
    - Run `cubic review` locally.
    - Fix issues found by cubic.
    - Re-run `cubic review`.
@@ -70,6 +71,7 @@ You execute a WikiSmith ClickUp ticket from intake to merge-ready completion wit
 - [ ] Acceptance criteria implemented
 - [ ] Tests added/updated for new behavior
 - [ ] Local lint/type-check/tests pass
+- [ ] Global `cubic` CLI is installed and available in `PATH`
 - [ ] Local `cubic review` reports no issues
 - [ ] PR created with summary and validation notes
 - [ ] CI checks green
@@ -80,3 +82,7 @@ You execute a WikiSmith ClickUp ticket from intake to merge-ready completion wit
 
 - WikiSmith often uses only `to do` and `complete` statuses.
 - When `in progress` is unavailable, use a start comment as the in-progress signal.
+
+## Environment Prerequisite
+
+- This skill expects the `cubic` CLI to be installed globally on the machine to run `cubic review`.

--- a/skills/clickup-ticket-implementer/SKILL.md
+++ b/skills/clickup-ticket-implementer/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: clickup-ticket-implementer
+description: Implement a ClickUp ticket end-to-end for WikiSmith: read ticket and PRD, implement with tests, run/fix local cubic review until clean, create PR, iterate on CI and review comments until clean, and close out ClickUp after merge.
+---
+
+# ClickUp Ticket Implementer
+
+## Role
+
+You execute a WikiSmith ClickUp ticket from intake to merge-ready completion with strict validation and feedback loops.
+
+## Inputs
+
+- Preferred: full ClickUp task URL (for example `https://app.clickup.com/t/86c8xxxx`).
+- Also supported: raw task ID (`86c8xxxx`) from user message or recent context.
+
+## Behavior
+
+1. **Read project conventions first**
+   - Read `AGENTS.md` before making changes.
+
+2. **Resolve ticket from context or user input**
+   - If a ClickUp URL is present, extract task ID.
+   - If only an ID is present, use it directly.
+   - Fetch task details via ClickUp MCP (`clickup_get_task`).
+
+3. **Understand requirements fully before coding**
+   - Parse task name, description, acceptance criteria, dependencies, and linked context.
+   - If the ticket references PRD files (usually under `features/*.md`), read those PRDs before implementing.
+   - Treat PRD requirements as source of truth unless the ticket explicitly overrides them.
+
+4. **Set task to active state**
+   - Attempt to set status to `in progress` when that status exists in the list/workspace.
+   - If `in progress` does not exist (WikiSmith commonly uses `to do` and `complete` only), add a start comment using `clickup_create_task_comment` explaining work has started and on which branch.
+
+5. **Implement the ticket completely**
+   - Create a branch using repo naming conventions (`feat/...`, `fix/...`, etc.).
+   - Implement all required backend/frontend/data-contract changes.
+   - Ensure ownership, auth, and error paths match project conventions.
+   - Add or update tests to cover acceptance criteria (unit/integration/E2E as appropriate).
+
+6. **Local quality loop (must be clean before PR)**
+   - Run relevant lint, type-check, and tests.
+   - Run `cubic review` locally.
+   - Fix issues found by cubic.
+   - Re-run `cubic review`.
+   - Repeat until local cubic reports no issues.
+
+7. **Create PR and validate CI**
+   - Commit with Conventional Commits.
+   - Push branch and create PR with clear summary + validation steps.
+   - Wait for all required pipelines/checks to become green.
+
+8. **Review feedback loop (no unresolved comments)**
+   - Collect PR review comments/threads.
+   - Fix valid issues, reply/resolve threads, and push updates.
+   - Re-run local lint/type-check/tests and `cubic review` after each change batch.
+   - Wait for CI checks again.
+   - Repeat until:
+     - required checks are green, and
+     - there are no unresolved actionable review comments/threads.
+
+9. **Closeout after merge**
+   - If human merges PR: reflect completion in ClickUp with PR link + key outcomes.
+   - If explicitly asked to merge: merge PR first, then reflect completion.
+   - Set task status to `complete`.
+
+## Required Validation Checklist
+
+- [ ] Acceptance criteria implemented
+- [ ] Tests added/updated for new behavior
+- [ ] Local lint/type-check/tests pass
+- [ ] Local `cubic review` reports no issues
+- [ ] PR created with summary and validation notes
+- [ ] CI checks green
+- [ ] All review comments addressed/resolved
+- [ ] ClickUp updated with progress and completion
+
+## ClickUp Notes for WikiSmith
+
+- WikiSmith often uses only `to do` and `complete` statuses.
+- When `in progress` is unavailable, use a start comment as the in-progress signal.


### PR DESCRIPTION
## Summary
- add a new project skill at `skills/clickup-ticket-implementer/SKILL.md` for end-to-end ClickUp ticket delivery
- define a full workflow: ticket/PRD intake, status handling, implementation, test coverage, local cubic loops, PR + CI + review-comment iteration, and ClickUp completion after merge
- wire the skill into both OpenCode and Cursor via symlinks:
  - `.agents/skills/clickup-ticket-implementer`
  - `.cursor/rules/clickup-ticket-implementer.md`

## Notes
- workflow includes an `in progress` attempt with fallback to start-comment when the list only supports `to do`/`complete`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a ClickUp ticket implementer skill for end-to-end delivery and updates docs to align the workflow, including cubic review and ClickUp status conventions. Wired into OpenCode and Cursor via symlinks for immediate use.

- New Features
  - New skill (skills/clickup-ticket-implementer/SKILL.md) for full workflow: fetch via ClickUp MCP, start comment when no “in progress”, implement with tests, run lint/type/tests and global cubic review until clean, open PR, iterate on CI/review, and close after merge.
  - Validation checklist includes cubic CLI installed in PATH, clean local checks, green CI, and all review threads resolved.
  - Symlinks added for OpenCode and Cursor; AGENTS.md updated to list the skill and document cubic review setup and ClickUp status rules.

<sup>Written for commit fc81e7d8b71d7251a87d79ec6beff4337ce4445c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

