### PR TITLE
feat(web): add live wiki link to primary navigation

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -8,6 +8,7 @@ import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { RepoInput } from '@/components/home/repo-input';
 import { RepositoryCardActions } from '@/components/dashboard/repository-card-actions';
+import { LiveWikiLink } from '@/components/navigation/live-wiki-link';
 import { AccountMenu } from '@/components/auth/account-menu';
 import { getSession } from '@/lib/auth/session';
 import { getDailyGenerationUsage } from '@/lib/auth/rate-limit';
@@ -182,7 +183,10 @@ const DashboardPage = async ({ searchParams }: DashboardPageProps) => {
             </p>
           </div>
 
-          <AccountMenu session={session} />
+          <div className="flex items-center gap-2">
+            <LiveWikiLink />
+            <AccountMenu session={session} />
+          </div>
         </header>
 
         <Card className="p-5 bg-zinc-900/70 border-zinc-800 space-y-4">

--- a/apps/web/src/components/auth/auth-nav.tsx
+++ b/apps/web/src/components/auth/auth-nav.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { signOut } from '@workos-inc/authkit-nextjs';
 import { Button } from '@/components/ui/button';
+import { LiveWikiLink } from '@/components/navigation/live-wiki-link';
 import type { AppSession } from '@/lib/auth/session';
 import { getGitHubSignInUrl } from '@/lib/auth/sign-in-url';
 
@@ -20,14 +21,20 @@ export const AuthNav = ({ session, returnPathname = '/dashboard', className }: A
     }
 
     return (
-      <Button asChild size="sm" className={className}>
-        <Link href={signInUrl}>Sign in</Link>
-      </Button>
+      <div
+        className={className ? `flex items-center gap-2 ${className}` : 'flex items-center gap-2'}
+      >
+        <LiveWikiLink />
+        <Button asChild size="sm">
+          <Link href={signInUrl}>Sign in</Link>
+        </Button>
+      </div>
     );
   }
 
   return (
     <div className={className ? `flex items-center gap-2 ${className}` : 'flex items-center gap-2'}>
+      <LiveWikiLink />
       <Button asChild size="sm" variant="secondary">
         <Link href="/dashboard">Dashboard</Link>
       </Button>

--- a/apps/web/src/components/navigation/live-wiki-link.tsx
+++ b/apps/web/src/components/navigation/live-wiki-link.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { LIVE_WIKI_LABEL, LIVE_WIKI_URL } from '@/lib/constants/live-wiki';
+
+interface LiveWikiLinkProps {
+  buttonVariant?: ComponentProps<typeof Button>['variant'];
+  buttonSize?: ComponentProps<typeof Button>['size'];
+  className?: string;
+}
+
+export const LiveWikiLink = ({
+  buttonVariant = 'outline',
+  buttonSize = 'sm',
+  className,
+}: LiveWikiLinkProps) => (
+  <Button asChild size={buttonSize} variant={buttonVariant} className={className}>
+    <a
+      href={LIVE_WIKI_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`${LIVE_WIKI_LABEL} (opens in a new tab)`}
+    >
+      <span>{LIVE_WIKI_LABEL}</span>
+      <ExternalLink className="size-3" aria-hidden="true" />
+    </a>
+  </Button>
+);

--- a/apps/web/src/components/wiki/wiki-reader-shell.tsx
+++ b/apps/web/src/components/wiki/wiki-reader-shell.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import type { StoredWikiContract } from '@wikismith/contracts';
 import type { IWikiPage } from '@wikismith/shared';
 import { Badge } from '@/components/ui/badge';
+import { LiveWikiLink } from '@/components/navigation/live-wiki-link';
 import { WikiSidebar } from '@/components/wiki/sidebar';
 import { WikiPageContent } from '@/components/wiki/page-content';
 
@@ -48,6 +49,7 @@ export const WikiReaderShell = ({
             {wiki.owner}/{wiki.repo}
           </span>
           <div className="ml-auto flex items-center justify-end gap-2 flex-wrap">
+            <LiveWikiLink />
             {headerActions}
             {showMetrics &&
               wiki.analysis.frameworks.map((framework) => (

--- a/apps/web/src/lib/constants/__tests__/live-wiki.test.ts
+++ b/apps/web/src/lib/constants/__tests__/live-wiki.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { LIVE_WIKI_LABEL, LIVE_WIKI_URL } from '@/lib/constants/live-wiki';
+
+describe('live wiki constants', () => {
+  it('exports the expected label and destination URL', () => {
+    expect(LIVE_WIKI_LABEL).toBe('Live Wiki');
+    expect(LIVE_WIKI_URL).toBe(
+      'https://wikismith.dudkin-garage.com/s/776e7126-1ef9-43a2-bf4b-1ee087851042',
+    );
+  });
+});

--- a/apps/web/src/lib/constants/live-wiki.ts
+++ b/apps/web/src/lib/constants/live-wiki.ts
@@ -1,0 +1,4 @@
+export const LIVE_WIKI_URL =
+  'https://wikismith.dudkin-garage.com/s/776e7126-1ef9-43a2-bf4b-1ee087851042';
+
+export const LIVE_WIKI_LABEL = 'Live Wiki';

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     globals: true,
     passWithNoTests: true,

--- a/features/wiki-navigation-public-link-prd.md
+++ b/features/wiki-navigation-public-link-prd.md
@@ -1,0 +1,49 @@
+# Wiki Navigation Public Link — PRD
+
+## Goal
+
+Add a persistent navigation link to the live public wiki so users can open it directly from the app navigation bar.
+
+## Problem Statement
+
+Users currently need to manually copy or remember the public wiki URL. This creates friction for demos, onboarding, and quick validation of the shared wiki experience.
+
+## User Stories
+
+- As a user visiting WikiSmith, I want a one-click link to the live public wiki so I can view the published experience immediately.
+- As a signed-in user, I want this link to stay visible in navigation so I can jump between app workflows and the public wiki.
+- As a first-time visitor, I want the link label to clearly indicate it opens a live wiki page.
+
+## Requirements
+
+- R-001: The primary navigation bar MUST include a dedicated link item for the public wiki.
+- R-002: The link URL MUST be exactly:
+  - `https://wikismith.dudkin-garage.com/s/776e7126-1ef9-43a2-bf4b-1ee087851042`
+- R-003: The link MUST be visible for both authenticated and unauthenticated users in nav surfaces where primary app navigation is rendered.
+- R-004: The link label MUST be explicit (proposed: `Live Wiki`).
+- R-005: The link MUST follow existing navigation styling conventions and remain usable on mobile and desktop.
+- R-006: Keyboard navigation and focus states MUST meet existing accessibility standards.
+
+## Technical Notes
+
+- Add the URL as a shared constant (avoid hardcoding it in multiple components).
+- Update the top-level navigation component(s), including the home page navigation area and any shared app-shell navigation used across authenticated views.
+- Reuse existing button/link styles from the design system (`Button` + `Link`) to keep visual consistency.
+- Add/adjust UI tests for nav presence and destination where coverage already exists.
+
+## Success Metrics
+
+- SM-001: 100% of primary nav renders include the `Live Wiki` link.
+- SM-002: Link destination is correct in manual QA and automated checks.
+- SM-003: No accessibility regressions in nav keyboard flow.
+
+## Out of Scope
+
+- Dynamic per-repository public wiki links.
+- Role-based visibility for the nav link.
+- Link analytics/dashboard reporting.
+
+## Open Questions
+
+- OQ-001: Should the link open in the same tab or a new tab by default?
+- OQ-002: Should the nav label be `Live Wiki`, `Public Wiki`, or `Example Wiki`?


### PR DESCRIPTION
## Summary
- add a shared live wiki navigation constant and reusable `LiveWikiLink` component pointing to the required public URL
- render `Live Wiki` in primary navigation surfaces for both signed-out and signed-in states (`AuthNav`, dashboard header, and wiki reader header)
- add PRD file for this ticket (`features/wiki-navigation-public-link-prd.md`) and test coverage for the live wiki constants
- update `apps/web/vitest.config.ts` with `@` path alias resolution so tests can consistently use app import aliases

## Validation
- `pnpm --filter @wikismith/web lint`
- `pnpm --filter @wikismith/web type-check`
- `pnpm --filter @wikismith/web test`
- `cubic review`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Live Wiki link to the primary navigation for both signed-in and signed-out users. Uses a reusable component and shared constants to make the public wiki easy to find.

- **New Features**
  - Reusable LiveWikiLink component using shared LIVE_WIKI_URL and label.
  - Link added to AuthNav, dashboard header, and wiki reader header for all users.
  - Unit tests for constants and Vitest alias for '@' imports.

<sup>Written for commit 6bd162bd3c6b06c5499af900d619846f41162104. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

