### PR TITLE
feat: implement embeddings pipeline and pgvector persistence

### DIFF
--- a/apps/web/src/lib/__tests__/wiki-store.test.ts
+++ b/apps/web/src/lib/__tests__/wiki-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockState = vi.hoisted(() => {
   const tables = {
@@ -23,11 +23,17 @@ const mockState = vi.hoisted(() => {
       createdAt: 'wikiPages.createdAt',
       id: 'wikiPages.id',
     },
+    wikiEmbeddings: {
+      wikiVersionId: 'wikiEmbeddings.wikiVersionId',
+      id: 'wikiEmbeddings.id',
+    },
   };
 
   return {
     tables,
     getStoredUserByWorkOSId: vi.fn(),
+    replaceWikiEmbeddings: vi.fn(),
+    embedChunks: vi.fn(),
     db: {
       insert: vi.fn(),
       update: vi.fn(),
@@ -43,6 +49,9 @@ const mockState = vi.hoisted(() => {
         },
         wikiPages: {
           findMany: vi.fn(),
+        },
+        wikiEmbeddings: {
+          findFirst: vi.fn(),
         },
       },
     },
@@ -62,9 +71,21 @@ vi.mock('@wikismith/db', () => ({
   repositories: mockState.tables.repositories,
   wikiVersions: mockState.tables.wikiVersions,
   wikiPages: mockState.tables.wikiPages,
+  wikiEmbeddings: mockState.tables.wikiEmbeddings,
+  replaceWikiEmbeddings: mockState.replaceWikiEmbeddings,
 }));
 
-import { deleteWiki, getWiki, saveWiki, type StoredWiki } from '../wiki-store';
+vi.mock('@wikismith/generator', () => ({
+  embedChunks: mockState.embedChunks,
+}));
+
+import {
+  deleteWiki,
+  getWiki,
+  saveWiki,
+  type StoredWiki,
+  waitForPendingEmbeddingJobsForTests,
+} from '../wiki-store';
 
 const setupDbMocks = () => {
   mockState.db.insert.mockImplementation((table: unknown) => {
@@ -133,9 +154,15 @@ const setupDbMocks = () => {
 describe('wiki-store DB persistence', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv('OPENAI_API_KEY', '');
     mockState.captured.wikiVersionValues = null;
     mockState.captured.wikiPageValues = null;
     setupDbMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('persists wiki versions keyed by commit hash', async () => {
@@ -199,6 +226,71 @@ describe('wiki-store DB persistence', () => {
     const [overview, child] = mockState.captured.wikiPageValues!;
     expect(overview?.['wikiVersionId']).toBe('version-1');
     expect(child?.['parentPageId']).toBe(overview?.['id']);
+  });
+
+  it('starts embedding generation in the background after persisting pages', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key');
+    mockState.getStoredUserByWorkOSId.mockResolvedValue({ id: 'user-1' });
+    mockState.db.query.repositories.findFirst.mockResolvedValue({
+      id: 'repo-1',
+      defaultBranch: 'main',
+      trackedBranch: 'main',
+      userId: 'user-1',
+    });
+    mockState.db.query.wikiVersions.findFirst.mockResolvedValue(null);
+    mockState.embedChunks.mockResolvedValue([
+      {
+        pageId: 'persisted-page-1',
+        sectionHeading: 'Overview',
+        chunkText: 'chunk text',
+        chunkIndex: 0,
+        tokenCount: 3,
+        embedding: [0.1, 0.2, 0.3],
+      },
+    ]);
+
+    await saveWiki({
+      generatedByWorkosId: 'user_workos_1',
+      owner: 'octocat',
+      repo: 'hello-world',
+      branch: 'main',
+      commitSha: 'abc123def456',
+      featureTree: {
+        repoId: 'octocat/hello-world',
+        commitSha: 'abc123def456',
+        generatedAt: new Date().toISOString(),
+        features: [],
+      },
+      analysis: {
+        languages: { TypeScript: 10 },
+        frameworks: ['nextjs'],
+        fileCount: 10,
+      },
+      pages: [
+        {
+          id: 'overview',
+          featureId: 'overview',
+          slug: 'overview',
+          title: 'Overview',
+          content: 'Overview content',
+          citations: [],
+          parentPageId: null,
+          order: 0,
+        },
+      ],
+      createdAt: new Date().toISOString(),
+    });
+
+    await waitForPendingEmbeddingJobsForTests();
+
+    expect(mockState.embedChunks).toHaveBeenCalledTimes(1);
+
+    expect(mockState.replaceWikiEmbeddings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryId: 'repo-1',
+        wikiVersionId: 'version-1',
+      }),
+    );
   });
 
   it('loads latest ready wiki from DB', async () => {

--- a/apps/web/src/lib/wiki-store.ts
+++ b/apps/web/src/lib/wiki-store.ts
@@ -4,6 +4,36 @@ import { getStoredUserByWorkOSId } from '@/lib/auth/user-store';
 
 type DbModule = typeof import('@wikismith/db');
 
+interface IEmbeddingPagePayload {
+  pageId: string;
+  title: string;
+  content: string;
+}
+
+const shouldTrackPendingEmbeddingJobs =
+  process.env['NODE_ENV'] === 'test' || process.env['VITEST'] === 'true';
+const pendingEmbeddingJobs = shouldTrackPendingEmbeddingJobs ? new Set<Promise<void>>() : null;
+
+const logError = (event: string, data: Record<string, unknown>): void => {
+  process.stderr.write(
+    `${JSON.stringify({
+      level: 'error',
+      event,
+      ...data,
+    })}\n`,
+  );
+};
+
+const logWarning = (event: string, data: Record<string, unknown>): void => {
+  process.stderr.write(
+    `${JSON.stringify({
+      level: 'warn',
+      event,
+      ...data,
+    })}\n`,
+  );
+};
+
 export interface StoredWiki {
   generatedByWorkosId?: string;
   owner: string;
@@ -44,6 +74,117 @@ const getUserId = async (workosId?: string): Promise<string | null> => {
 
   const user = await getStoredUserByWorkOSId(workosId);
   return user?.id ?? null;
+};
+
+const runWikiEmbeddingPipeline = async (params: {
+  repositoryId: string;
+  wikiVersionId: string;
+  pages: IEmbeddingPagePayload[];
+  replaceWikiEmbeddings: DbModule['replaceWikiEmbeddings'];
+}): Promise<void> => {
+  if (!process.env['OPENAI_API_KEY']) {
+    if (process.env['NODE_ENV'] !== 'test') {
+      logWarning('wiki.embedding_pipeline_skipped_missing_openai_key', {
+        repositoryId: params.repositoryId,
+        wikiVersionId: params.wikiVersionId,
+      });
+    }
+
+    return;
+  }
+
+  const { embedChunks } = await import('@wikismith/generator');
+  const embeddedChunks = await embedChunks({ pages: params.pages });
+
+  await params.replaceWikiEmbeddings({
+    repositoryId: params.repositoryId,
+    wikiVersionId: params.wikiVersionId,
+    chunks: embeddedChunks.map((chunk) => ({
+      wikiPageId: chunk.pageId,
+      chunkIndex: chunk.chunkIndex,
+      sectionHeading: chunk.sectionHeading,
+      chunkText: chunk.chunkText,
+      embedding: chunk.embedding,
+      metadata: {
+        page_id: chunk.pageId,
+        section_heading: chunk.sectionHeading,
+        repo_id: params.repositoryId,
+        wiki_version_id: params.wikiVersionId,
+        chunk_text: chunk.chunkText,
+      },
+    })),
+  });
+};
+
+const startWikiEmbeddingPipeline = (params: {
+  repositoryId: string;
+  wikiVersionId: string;
+  pages: IEmbeddingPagePayload[];
+  replaceWikiEmbeddings: DbModule['replaceWikiEmbeddings'];
+}): void => {
+  const job = runWikiEmbeddingPipeline(params).catch((error) => {
+    logError('wiki.embedding_pipeline_failed', {
+      repositoryId: params.repositoryId,
+      wikiVersionId: params.wikiVersionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  if (pendingEmbeddingJobs) {
+    pendingEmbeddingJobs.add(job);
+    void job.finally(() => {
+      pendingEmbeddingJobs.delete(job);
+    });
+  }
+};
+
+const recoverMissingEmbeddings = (params: {
+  db: DbModule['db'];
+  wikiEmbeddings: DbModule['wikiEmbeddings'];
+  replaceWikiEmbeddings: DbModule['replaceWikiEmbeddings'];
+  repositoryId: string;
+  wikiVersionId: string;
+  pages: IEmbeddingPagePayload[];
+}): void => {
+  if (!process.env['OPENAI_API_KEY']) {
+    return;
+  }
+
+  const job = (async () => {
+    const existingEmbedding = await params.db.query.wikiEmbeddings.findFirst({
+      where: eq(params.wikiEmbeddings.wikiVersionId, params.wikiVersionId),
+      columns: {
+        id: true,
+      },
+    });
+
+    if (existingEmbedding) {
+      return;
+    }
+
+    startWikiEmbeddingPipeline({
+      repositoryId: params.repositoryId,
+      wikiVersionId: params.wikiVersionId,
+      pages: params.pages,
+      replaceWikiEmbeddings: params.replaceWikiEmbeddings,
+    });
+  })();
+
+  void job.catch((error) => {
+    logError('wiki.embedding_recovery_failed', {
+      repositoryId: params.repositoryId,
+      wikiVersionId: params.wikiVersionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+};
+
+export const waitForPendingEmbeddingJobsForTests = async (): Promise<void> => {
+  if (!pendingEmbeddingJobs || pendingEmbeddingJobs.size === 0) {
+    return;
+  }
+
+  await Promise.allSettled(Array.from(pendingEmbeddingJobs));
 };
 
 const toStoredWiki = (
@@ -178,7 +319,7 @@ export const saveWiki = async (wiki: StoredWiki): Promise<void> => {
     throw new Error('generatedByWorkosId is required to persist wiki data.');
   }
 
-  const { db, repositories, wikiVersions, wikiPages } = await loadDb();
+  const { db, repositories, wikiVersions, wikiPages, replaceWikiEmbeddings } = await loadDb();
   const user = await getStoredUserByWorkOSId(wiki.generatedByWorkosId);
 
   if (!user) {
@@ -292,32 +433,43 @@ export const saveWiki = async (wiki: StoredWiki): Promise<void> => {
 
   await db.delete(wikiPages).where(eq(wikiPages.wikiVersionId, version.id));
 
-  await db.insert(wikiPages).values(
-    wiki.pages.map((page) => {
-      const id = pageIdMap.get(page.id);
-      const parentPageId = page.parentPageId ? pageIdMap.get(page.parentPageId) : null;
+  const pagesToPersist = wiki.pages.map((page) => {
+    const id = pageIdMap.get(page.id);
+    const parentPageId = page.parentPageId ? pageIdMap.get(page.parentPageId) : null;
 
-      if (!id) {
-        throw new Error(`Wiki page id mapping is missing for: ${page.id}`);
-      }
+    if (!id) {
+      throw new Error(`Wiki page id mapping is missing for: ${page.id}`);
+    }
 
-      if (page.parentPageId && !parentPageId) {
-        throw new Error(`Wiki page parent reference is invalid: ${page.parentPageId}`);
-      }
+    if (page.parentPageId && !parentPageId) {
+      throw new Error(`Wiki page parent reference is invalid: ${page.parentPageId}`);
+    }
 
-      return {
-        id,
-        wikiVersionId: version.id,
-        featureId: page.featureId,
-        slug: page.slug,
-        title: page.title,
-        content: page.content,
-        citations: page.citations,
-        parentPageId,
-        sortOrder: page.order,
-      };
-    }),
-  );
+    return {
+      id,
+      wikiVersionId: version.id,
+      featureId: page.featureId,
+      slug: page.slug,
+      title: page.title,
+      content: page.content,
+      citations: page.citations,
+      parentPageId,
+      sortOrder: page.order,
+    };
+  });
+
+  await db.insert(wikiPages).values(pagesToPersist);
+
+  startWikiEmbeddingPipeline({
+    repositoryId: repository.id,
+    wikiVersionId: version.id,
+    pages: pagesToPersist.map((page) => ({
+      pageId: page.id,
+      title: page.title,
+      content: page.content,
+    })),
+    replaceWikiEmbeddings,
+  });
 };
 
 export const getWiki = async (
@@ -330,12 +482,25 @@ export const getWiki = async (
     return undefined;
   }
 
-  const { db, wikiVersions, wikiPages } = await loadDb();
+  const { db, wikiVersions, wikiPages, wikiEmbeddings, replaceWikiEmbeddings } = await loadDb();
 
   const wikiData = await getLatestReadyWikiData(db, wikiVersions, wikiPages, repository.id);
   if (!wikiData) {
     return undefined;
   }
+
+  recoverMissingEmbeddings({
+    db,
+    wikiEmbeddings,
+    replaceWikiEmbeddings,
+    repositoryId: repository.id,
+    wikiVersionId: wikiData.version.id,
+    pages: wikiData.pages.map((page) => ({
+      pageId: page.id,
+      title: page.title,
+      content: page.content,
+    })),
+  });
 
   return toStoredWiki(owner, repo, workosId, wikiData.version, wikiData.pages);
 };
@@ -389,7 +554,15 @@ export const getPublicWikiByShareToken = async (
   shareToken: string,
   options: PublicWikiLookupOptions = {},
 ): Promise<StoredWiki | undefined> => {
-  const { db, wikiShares, repositories, wikiVersions, wikiPages } = await loadDb();
+  const {
+    db,
+    wikiShares,
+    repositories,
+    wikiVersions,
+    wikiPages,
+    wikiEmbeddings,
+    replaceWikiEmbeddings,
+  } = await loadDb();
 
   const share = await db.query.wikiShares.findFirst({
     where: and(eq(wikiShares.shareToken, shareToken), eq(wikiShares.isPublic, true)),
@@ -423,6 +596,19 @@ export const getPublicWikiByShareToken = async (
   if (!wikiData) {
     return undefined;
   }
+
+  recoverMissingEmbeddings({
+    db,
+    wikiEmbeddings,
+    replaceWikiEmbeddings,
+    repositoryId: share.repositoryId,
+    wikiVersionId: wikiData.version.id,
+    pages: wikiData.pages.map((page) => ({
+      pageId: page.id,
+      title: page.title,
+      content: page.content,
+    })),
+  });
 
   return toStoredWiki(
     repository.owner,

--- a/apps/web/src/lib/wiki-store.ts
+++ b/apps/web/src/lib/wiki-store.ts
@@ -34,6 +34,17 @@ const logWarning = (event: string, data: Record<string, unknown>): void => {
   );
 };
 
+const trackPendingEmbeddingJob = (job: Promise<void>): void => {
+  if (!pendingEmbeddingJobs) {
+    return;
+  }
+
+  pendingEmbeddingJobs.add(job);
+  void job.finally(() => {
+    pendingEmbeddingJobs.delete(job);
+  });
+};
+
 export interface StoredWiki {
   generatedByWorkosId?: string;
   owner: string;
@@ -122,7 +133,8 @@ const startWikiEmbeddingPipeline = (params: {
   pages: IEmbeddingPagePayload[];
   replaceWikiEmbeddings: DbModule['replaceWikiEmbeddings'];
 }): void => {
-  const job = runWikiEmbeddingPipeline(params).catch((error) => {
+  const job = runWikiEmbeddingPipeline(params);
+  void job.catch((error) => {
     logError('wiki.embedding_pipeline_failed', {
       repositoryId: params.repositoryId,
       wikiVersionId: params.wikiVersionId,
@@ -130,12 +142,7 @@ const startWikiEmbeddingPipeline = (params: {
     });
   });
 
-  if (pendingEmbeddingJobs) {
-    pendingEmbeddingJobs.add(job);
-    void job.finally(() => {
-      pendingEmbeddingJobs.delete(job);
-    });
-  }
+  trackPendingEmbeddingJob(job);
 };
 
 const recoverMissingEmbeddings = (params: {
@@ -177,6 +184,8 @@ const recoverMissingEmbeddings = (params: {
       error: error instanceof Error ? error.message : String(error),
     });
   });
+
+  trackPendingEmbeddingJob(job);
 };
 
 export const waitForPendingEmbeddingJobsForTests = async (): Promise<void> => {

--- a/packages/db/drizzle/0006_easy_cassandra_nova.sql
+++ b/packages/db/drizzle/0006_easy_cassandra_nova.sql
@@ -16,6 +16,7 @@ CREATE TABLE "wiki_embeddings" (
 ALTER TABLE "wiki_embeddings" ADD CONSTRAINT "wiki_embeddings_repository_id_repositories_id_fk" FOREIGN KEY ("repository_id") REFERENCES "public"."repositories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "wiki_embeddings" ADD CONSTRAINT "wiki_embeddings_wiki_version_id_wiki_versions_id_fk" FOREIGN KEY ("wiki_version_id") REFERENCES "public"."wiki_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "wiki_embeddings" ADD CONSTRAINT "wiki_embeddings_wiki_page_id_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_id") REFERENCES "public"."wiki_pages"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "wiki_embeddings_repository_idx" ON "wiki_embeddings" USING btree ("repository_id");--> statement-breakpoint
 CREATE INDEX "wiki_embeddings_wiki_version_idx" ON "wiki_embeddings" USING btree ("wiki_version_id");--> statement-breakpoint
 CREATE INDEX "wiki_embeddings_wiki_page_idx" ON "wiki_embeddings" USING btree ("wiki_page_id");--> statement-breakpoint
 CREATE INDEX "wiki_embeddings_embedding_hnsw_idx" ON "wiki_embeddings" USING hnsw ("embedding" vector_cosine_ops);

--- a/packages/db/drizzle/0006_easy_cassandra_nova.sql
+++ b/packages/db/drizzle/0006_easy_cassandra_nova.sql
@@ -1,0 +1,21 @@
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
+CREATE TABLE "wiki_embeddings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repository_id" uuid NOT NULL,
+	"wiki_version_id" uuid NOT NULL,
+	"wiki_page_id" uuid NOT NULL,
+	"chunk_index" integer NOT NULL,
+	"section_heading" text NOT NULL,
+	"chunk_text" text NOT NULL,
+	"embedding" vector(1536) NOT NULL,
+	"metadata" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "wiki_embeddings" ADD CONSTRAINT "wiki_embeddings_repository_id_repositories_id_fk" FOREIGN KEY ("repository_id") REFERENCES "public"."repositories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_embeddings" ADD CONSTRAINT "wiki_embeddings_wiki_version_id_wiki_versions_id_fk" FOREIGN KEY ("wiki_version_id") REFERENCES "public"."wiki_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "wiki_embeddings" ADD CONSTRAINT "wiki_embeddings_wiki_page_id_wiki_pages_id_fk" FOREIGN KEY ("wiki_page_id") REFERENCES "public"."wiki_pages"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "wiki_embeddings_wiki_version_idx" ON "wiki_embeddings" USING btree ("wiki_version_id");--> statement-breakpoint
+CREATE INDEX "wiki_embeddings_wiki_page_idx" ON "wiki_embeddings" USING btree ("wiki_page_id");--> statement-breakpoint
+CREATE INDEX "wiki_embeddings_embedding_hnsw_idx" ON "wiki_embeddings" USING hnsw ("embedding" vector_cosine_ops);

--- a/packages/db/drizzle/meta/0006_snapshot.json
+++ b/packages/db/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1064 @@
+{
+  "id": "11c96a1f-ee13-4d9a-9a5d-15252a0b4c53",
+  "prevId": "8a216a3b-7840-459d-b603-9c8a007683ca",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.generation_jobs": {
+      "name": "generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wiki_version_id": {
+          "name": "wiki_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generation_jobs_wiki_version_id_wiki_versions_id_fk": {
+          "name": "generation_jobs_wiki_version_id_wiki_versions_id_fk",
+          "tableFrom": "generation_jobs",
+          "tableTo": "wiki_versions",
+          "columnsFrom": [
+            "wiki_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generation_rate_limits": {
+      "name": "generation_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_date": {
+          "name": "bucket_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "generation_rate_limits_user_bucket_unique": {
+          "name": "generation_rate_limits_user_bucket_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "generation_rate_limits_user_id_users_id_fk": {
+          "name": "generation_rate_limits_user_id_users_id_fk",
+          "tableFrom": "generation_rate_limits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_request_rate_limits": {
+      "name": "public_request_rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "public_request_rate_limits_request_route_bucket_unique": {
+          "name": "public_request_rate_limits_request_route_bucket_unique",
+          "columns": [
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "route",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'main'"
+        },
+        "tracked_branch": {
+          "name": "tracked_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_update": {
+          "name": "auto_update",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "repositories_user_full_name_unique": {
+          "name": "repositories_user_full_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "repositories_user_id_users_id_fk": {
+          "name": "repositories_user_id_users_id_fk",
+          "tableFrom": "repositories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workos_id": {
+          "name": "workos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_token_encrypted": {
+          "name": "github_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_token_iv": {
+          "name": "github_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_token_tag": {
+          "name": "github_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_refresh_token_encrypted": {
+          "name": "github_refresh_token_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_refresh_token_iv": {
+          "name": "github_refresh_token_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_refresh_token_tag": {
+          "name": "github_refresh_token_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_token_expires_at": {
+          "name": "github_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_workos_id_unique": {
+          "name": "users_workos_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workos_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_embeddings": {
+      "name": "wiki_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_version_id": {
+          "name": "wiki_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wiki_page_id": {
+          "name": "wiki_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_heading": {
+          "name": "section_heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_text": {
+          "name": "chunk_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wiki_embeddings_wiki_version_idx": {
+          "name": "wiki_embeddings_wiki_version_idx",
+          "columns": [
+            {
+              "expression": "wiki_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wiki_embeddings_wiki_page_idx": {
+          "name": "wiki_embeddings_wiki_page_idx",
+          "columns": [
+            {
+              "expression": "wiki_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wiki_embeddings_embedding_hnsw_idx": {
+          "name": "wiki_embeddings_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_embeddings_repository_id_repositories_id_fk": {
+          "name": "wiki_embeddings_repository_id_repositories_id_fk",
+          "tableFrom": "wiki_embeddings",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wiki_embeddings_wiki_version_id_wiki_versions_id_fk": {
+          "name": "wiki_embeddings_wiki_version_id_wiki_versions_id_fk",
+          "tableFrom": "wiki_embeddings",
+          "tableTo": "wiki_versions",
+          "columnsFrom": [
+            "wiki_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wiki_embeddings_wiki_page_id_wiki_pages_id_fk": {
+          "name": "wiki_embeddings_wiki_page_id_wiki_pages_id_fk",
+          "tableFrom": "wiki_embeddings",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "wiki_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_pages": {
+      "name": "wiki_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "wiki_version_id": {
+          "name": "wiki_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "parent_page_id": {
+          "name": "parent_page_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wiki_pages_wiki_version_id_wiki_versions_id_fk": {
+          "name": "wiki_pages_wiki_version_id_wiki_versions_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_versions",
+          "columnsFrom": [
+            "wiki_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wiki_pages_parent_page_id_wiki_pages_id_fk": {
+          "name": "wiki_pages_parent_page_id_wiki_pages_id_fk",
+          "tableFrom": "wiki_pages",
+          "tableTo": "wiki_pages",
+          "columnsFrom": [
+            "parent_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_shares": {
+      "name": "wiki_shares",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "embed_enabled": {
+          "name": "embed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "token_rotated_at": {
+          "name": "token_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wiki_shares_repository_unique": {
+          "name": "wiki_shares_repository_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wiki_shares_share_token_unique": {
+          "name": "wiki_shares_share_token_unique",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_shares_repository_id_repositories_id_fk": {
+          "name": "wiki_shares_repository_id_repositories_id_fk",
+          "tableFrom": "wiki_shares",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wiki_versions": {
+      "name": "wiki_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_tree": {
+          "name": "feature_tree",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_count": {
+          "name": "feature_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wiki_versions_repository_commit_unique": {
+          "name": "wiki_versions_repository_commit_unique",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "commit_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wiki_versions_repository_status_generated_at_idx": {
+          "name": "wiki_versions_repository_status_generated_at_idx",
+          "columns": [
+            {
+              "expression": "repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wiki_versions_repository_id_repositories_id_fk": {
+          "name": "wiki_versions_repository_id_repositories_id_fk",
+          "tableFrom": "wiki_versions",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1772121431929,
       "tag": "0005_watery_groot",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772129611273,
+      "tag": "0006_easy_cassandra_nova",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/embeddings.ts
+++ b/packages/db/src/embeddings.ts
@@ -56,16 +56,13 @@ const toMetadataRecord = (value: unknown): Record<string, unknown> =>
     ? (value as Record<string, unknown>)
     : {};
 
-const toVectorSql = (embedding: number[]): SQL => {
+const toVectorLiteral = (embedding: number[]): string => {
   validateEmbedding(embedding);
 
-  const values = sql.join(
-    embedding.map((value) => sql`${value}`),
-    sql`, `,
-  );
-
-  return sql`ARRAY[${values}]::vector`;
+  return `[${embedding.join(',')}]`;
 };
+
+const toVectorSql = (embedding: number[]): SQL => sql`${toVectorLiteral(embedding)}::vector`;
 
 export const replaceWikiEmbeddings = async (input: IReplaceWikiEmbeddingsInput): Promise<void> => {
   await db.transaction(async (tx) => {

--- a/packages/db/src/embeddings.ts
+++ b/packages/db/src/embeddings.ts
@@ -1,0 +1,153 @@
+import { eq, sql, type SQL } from 'drizzle-orm';
+import { db } from './client';
+import { wikiEmbeddings } from './schema';
+
+export interface IWikiEmbeddingRecord {
+  wikiPageId: string;
+  chunkIndex: number;
+  sectionHeading: string;
+  chunkText: string;
+  embedding: number[];
+  metadata: {
+    page_id: string;
+    section_heading: string;
+    repo_id: string;
+    wiki_version_id: string;
+    chunk_text: string;
+  };
+}
+
+export interface IReplaceWikiEmbeddingsInput {
+  repositoryId: string;
+  wikiVersionId: string;
+  chunks: IWikiEmbeddingRecord[];
+}
+
+export interface IFindSimilarWikiEmbeddingsInput {
+  wikiVersionId: string;
+  queryEmbedding: number[];
+  limit?: number;
+}
+
+export interface ISimilarWikiEmbedding {
+  id: string;
+  wikiPageId: string;
+  sectionHeading: string;
+  chunkText: string;
+  metadata: Record<string, unknown>;
+  similarity: number;
+}
+
+const validateEmbedding = (embedding: number[]): void => {
+  if (embedding.length === 0) {
+    throw new Error('Embedding vector cannot be empty.');
+  }
+
+  const hasInvalidValue = embedding.some((value) => !Number.isFinite(value));
+  if (hasInvalidValue) {
+    throw new Error('Embedding vector must contain only finite numeric values.');
+  }
+};
+
+const MAX_SIMILARITY_LIMIT = 100;
+
+const toMetadataRecord = (value: unknown): Record<string, unknown> =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+const toVectorSql = (embedding: number[]): SQL => {
+  validateEmbedding(embedding);
+
+  const values = sql.join(
+    embedding.map((value) => sql`${value}`),
+    sql`, `,
+  );
+
+  return sql`ARRAY[${values}]::vector`;
+};
+
+export const replaceWikiEmbeddings = async (input: IReplaceWikiEmbeddingsInput): Promise<void> => {
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${input.repositoryId})::int, hashtext(${input.wikiVersionId})::int)`,
+    );
+
+    await tx.delete(wikiEmbeddings).where(eq(wikiEmbeddings.wikiVersionId, input.wikiVersionId));
+
+    if (input.chunks.length === 0) {
+      return;
+    }
+
+    await tx.insert(wikiEmbeddings).values(
+      input.chunks.map((chunk) => {
+        validateEmbedding(chunk.embedding);
+
+        return {
+          repositoryId: input.repositoryId,
+          wikiVersionId: input.wikiVersionId,
+          wikiPageId: chunk.wikiPageId,
+          chunkIndex: chunk.chunkIndex,
+          sectionHeading: chunk.sectionHeading,
+          chunkText: chunk.chunkText,
+          embedding: chunk.embedding,
+          metadata: chunk.metadata,
+        };
+      }),
+    );
+  });
+};
+
+export const findSimilarWikiEmbeddings = async (
+  input: IFindSimilarWikiEmbeddingsInput,
+): Promise<ISimilarWikiEmbedding[]> => {
+  const queryVector = toVectorSql(input.queryEmbedding);
+  const limit = Math.min(MAX_SIMILARITY_LIMIT, Math.max(1, input.limit ?? 10));
+
+  const result = await db.execute(sql`
+    SELECT
+      id,
+      wiki_page_id AS "wikiPageId",
+      section_heading AS "sectionHeading",
+      chunk_text AS "chunkText",
+      metadata,
+      -- pgvector <=> returns cosine distance, so we convert to similarity with (1 - distance).
+      1 - (embedding <=> ${queryVector}) AS similarity
+    FROM wiki_embeddings
+    WHERE wiki_version_id = ${input.wikiVersionId}
+    ORDER BY embedding <=> ${queryVector}
+    LIMIT ${limit}
+  `);
+
+  return result.rows.map((row) => {
+    const id = row['id'];
+    const wikiPageId = row['wikiPageId'];
+    const sectionHeading = row['sectionHeading'];
+    const chunkText = row['chunkText'];
+    const metadata = row['metadata'];
+    const similarity = row['similarity'];
+
+    if (
+      typeof id !== 'string' ||
+      typeof wikiPageId !== 'string' ||
+      typeof sectionHeading !== 'string' ||
+      typeof chunkText !== 'string'
+    ) {
+      throw new Error('Unexpected similarity row payload from wiki embeddings query.');
+    }
+
+    return {
+      id,
+      wikiPageId,
+      sectionHeading,
+      chunkText,
+      metadata: toMetadataRecord(metadata),
+      similarity:
+        typeof similarity === 'number'
+          ? similarity
+          : Number.isFinite(Number(similarity))
+            ? Number(similarity)
+            : 0,
+    };
+  });
+};

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,2 +1,10 @@
 export { db } from './client';
+export {
+  replaceWikiEmbeddings,
+  findSimilarWikiEmbeddings,
+  type IWikiEmbeddingRecord,
+  type IReplaceWikiEmbeddingsInput,
+  type IFindSimilarWikiEmbeddingsInput,
+  type ISimilarWikiEmbedding,
+} from './embeddings';
 export * from './schema';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -11,13 +11,8 @@ import {
   date,
   index,
   uniqueIndex,
-  customType,
+  vector,
 } from 'drizzle-orm/pg-core';
-
-const vector = customType<{ data: number[]; driverData: string; config: { dimensions: number } }>({
-  dataType: (config) => `vector(${config?.dimensions ?? 1536})`,
-  toDriver: (value) => `[${value.join(',')}]`,
-});
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -11,7 +11,13 @@ import {
   date,
   index,
   uniqueIndex,
+  customType,
 } from 'drizzle-orm/pg-core';
+
+const vector = customType<{ data: number[]; driverData: string; config: { dimensions: number } }>({
+  dataType: (config) => `vector(${config?.dimensions ?? 1536})`,
+  toDriver: (value) => `[${value.join(',')}]`,
+});
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -139,6 +145,44 @@ export const wikiPages = pgTable('wiki_pages', {
   sortOrder: integer('sort_order').default(0).notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 });
+
+export const wikiEmbeddings = pgTable(
+  'wiki_embeddings',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    repositoryId: uuid('repository_id')
+      .references(() => repositories.id, { onDelete: 'cascade' })
+      .notNull(),
+    wikiVersionId: uuid('wiki_version_id')
+      .references(() => wikiVersions.id, { onDelete: 'cascade' })
+      .notNull(),
+    wikiPageId: uuid('wiki_page_id')
+      .references(() => wikiPages.id, { onDelete: 'cascade' })
+      .notNull(),
+    chunkIndex: integer('chunk_index').notNull(),
+    sectionHeading: text('section_heading').notNull(),
+    chunkText: text('chunk_text').notNull(),
+    embedding: vector('embedding', { dimensions: 1536 }).notNull(),
+    metadata: jsonb('metadata')
+      .$type<{
+        page_id: string;
+        section_heading: string;
+        repo_id: string;
+        wiki_version_id: string;
+        chunk_text: string;
+      }>()
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    wikiVersionIndex: index('wiki_embeddings_wiki_version_idx').on(table.wikiVersionId),
+    wikiPageIndex: index('wiki_embeddings_wiki_page_idx').on(table.wikiPageId),
+    embeddingHnswIndex: index('wiki_embeddings_embedding_hnsw_idx').using(
+      'hnsw',
+      table.embedding.op('vector_cosine_ops'),
+    ),
+  }),
+);
 
 export const generationJobs = pgTable('generation_jobs', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@wikismith/shared": "workspace:*",
+    "gpt-tokenizer": "^3.4.0",
     "openai": "^6.25.0"
   },
   "devDependencies": {

--- a/packages/generator/src/__tests__/embed-chunks.test.ts
+++ b/packages/generator/src/__tests__/embed-chunks.test.ts
@@ -1,0 +1,94 @@
+import { encode } from 'gpt-tokenizer';
+import { describe, expect, it, vi } from 'vitest';
+import { chunkWikiPages, embedChunks } from '../embed-chunks';
+
+const makeTokens = (prefix: string, count: number): string =>
+  Array.from({ length: count }, (_, index) => `${prefix}-${index + 1}`).join(' ');
+
+describe('chunkWikiPages', () => {
+  it('chunks markdown into 500-1000 token windows with overlap', () => {
+    const page = {
+      pageId: 'page-1',
+      title: 'Architecture',
+      content: [
+        '## Overview',
+        makeTokens('overview', 700),
+        '',
+        '### Data flow',
+        makeTokens('data', 700),
+      ].join('\n'),
+    };
+
+    const chunks = chunkWikiPages({
+      pages: [page],
+      minTokens: 500,
+      maxTokens: 1000,
+      overlapTokens: 100,
+    });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    chunks.forEach((chunk) => {
+      expect(chunk.tokenCount).toBeLessThanOrEqual(1000);
+      expect(chunk.pageId).toBe('page-1');
+    });
+
+    const firstChunkTokens = encode(chunks[0]!.chunkText);
+    const secondChunkTokens = encode(chunks[1]!.chunkText);
+    const firstChunkOverlap = firstChunkTokens.slice(-100);
+    const secondChunkOverlap = secondChunkTokens.slice(0, 100);
+
+    expect(secondChunkOverlap).toEqual(firstChunkOverlap);
+  });
+});
+
+describe('embedChunks', () => {
+  it('embeds in batches and preserves chunk metadata', async () => {
+    const page = {
+      pageId: 'page-1',
+      title: 'Authentication',
+      content: ['## Intro', makeTokens('intro', 30)].join('\n'),
+    };
+    const chunkingConfig = {
+      pages: [page],
+      minTokens: 4,
+      maxTokens: 8,
+      overlapTokens: 2,
+      batchSize: 2,
+    };
+    const expectedChunkCount = chunkWikiPages(chunkingConfig).length;
+    const expectedBatchCalls = Math.ceil(expectedChunkCount / 2);
+
+    const create = vi.fn(async ({ input }: { model: string; input: string[] }) => ({
+      data: input.map((_, index) => ({ embedding: [index + 1, 0.5, 0.25] })),
+    }));
+
+    const embedded = await embedChunks(chunkingConfig, {
+      client: {
+        embeddings: {
+          create,
+        },
+      },
+    });
+
+    expect(embedded.length).toBe(expectedChunkCount);
+    expect(create).toHaveBeenCalledTimes(expectedBatchCalls);
+    expect(embedded[0]?.embedding).toEqual([1, 0.5, 0.25]);
+    expect(embedded[0]?.pageId).toBe('page-1');
+    expect(embedded[0]?.tokenCount).toBeLessThanOrEqual(8);
+  });
+
+  it('throws when no client or API key is provided', async () => {
+    const originalApiKey = process.env['OPENAI_API_KEY'];
+    delete process.env['OPENAI_API_KEY'];
+
+    await expect(
+      embedChunks({
+        pages: [{ pageId: 'page-1', title: 'Overview', content: '## Summary\nHello world' }],
+      }),
+    ).rejects.toThrow('OPENAI_API_KEY is required');
+
+    if (originalApiKey) {
+      process.env['OPENAI_API_KEY'] = originalApiKey;
+    }
+  });
+});

--- a/packages/generator/src/__tests__/embed-chunks.test.ts
+++ b/packages/generator/src/__tests__/embed-chunks.test.ts
@@ -81,14 +81,18 @@ describe('embedChunks', () => {
     const originalApiKey = process.env['OPENAI_API_KEY'];
     delete process.env['OPENAI_API_KEY'];
 
-    await expect(
-      embedChunks({
-        pages: [{ pageId: 'page-1', title: 'Overview', content: '## Summary\nHello world' }],
-      }),
-    ).rejects.toThrow('OPENAI_API_KEY is required');
-
-    if (originalApiKey) {
-      process.env['OPENAI_API_KEY'] = originalApiKey;
+    try {
+      await expect(
+        embedChunks({
+          pages: [{ pageId: 'page-1', title: 'Overview', content: '## Summary\nHello world' }],
+        }),
+      ).rejects.toThrow('OPENAI_API_KEY is required');
+    } finally {
+      if (originalApiKey === undefined) {
+        delete process.env['OPENAI_API_KEY'];
+      } else {
+        process.env['OPENAI_API_KEY'] = originalApiKey;
+      }
     }
   });
 });

--- a/packages/generator/src/embed-chunks.ts
+++ b/packages/generator/src/embed-chunks.ts
@@ -1,0 +1,313 @@
+import { decode, encode } from 'gpt-tokenizer';
+import OpenAI from 'openai';
+
+export interface IPageForEmbedding {
+  pageId: string;
+  title: string;
+  content: string;
+}
+
+export interface IChunkWikiPagesInput {
+  pages: IPageForEmbedding[];
+  minTokens?: number;
+  maxTokens?: number;
+  overlapTokens?: number;
+}
+
+export interface IChunkedWikiSection {
+  pageId: string;
+  sectionHeading: string;
+  chunkText: string;
+  chunkIndex: number;
+  tokenCount: number;
+}
+
+export interface IEmbeddedWikiSection extends IChunkedWikiSection {
+  embedding: number[];
+}
+
+export interface IEmbedChunksInput extends IChunkWikiPagesInput {
+  openaiApiKey?: string;
+  model?: string;
+  batchSize?: number;
+}
+
+interface IEmbeddingClient {
+  embeddings: {
+    create: (params: { model: string; input: string[] }) => Promise<{
+      data: Array<{
+        embedding: number[];
+      }>;
+    }>;
+  };
+}
+
+interface ISection {
+  heading: string;
+  content: string;
+}
+
+interface ITokenWithHeading {
+  tokenId: number;
+  heading: string;
+}
+
+const DEFAULT_MIN_TOKENS = 500;
+const DEFAULT_MAX_TOKENS = 1000;
+const DEFAULT_OVERLAP_TOKENS = 100;
+const DEFAULT_BATCH_SIZE = 2048;
+const MAX_EMBEDDING_RETRIES = 3;
+const EMBEDDING_RETRY_BASE_DELAY_MS = 300;
+
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const getErrorStatusCode = (error: unknown): number | null => {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return null;
+  }
+
+  const status = (error as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
+};
+
+const isRetryableEmbeddingError = (error: unknown): boolean => {
+  const status = getErrorStatusCode(error);
+  return status === 429 || (status !== null && status >= 500 && status < 600);
+};
+
+const createEmbeddingsWithRetry = async (
+  openai: OpenAI,
+  model: string,
+  input: string[],
+): Promise<{
+  data: Array<{
+    embedding: number[];
+  }>;
+}> => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_EMBEDDING_RETRIES; attempt += 1) {
+    try {
+      const response = await openai.embeddings.create({ model, input });
+      return {
+        data: response.data.map((entry) => ({
+          embedding: entry.embedding,
+        })),
+      };
+    } catch (error) {
+      lastError = error;
+
+      if (!isRetryableEmbeddingError(error) || attempt === MAX_EMBEDDING_RETRIES) {
+        throw new Error('Failed to create embeddings from OpenAI API.', { cause: error });
+      }
+
+      await sleep(EMBEDDING_RETRY_BASE_DELAY_MS * 2 ** attempt);
+    }
+  }
+
+  throw new Error('Failed to create embeddings from OpenAI API.', { cause: lastError });
+};
+
+const extractSections = (pageTitle: string, markdown: string): ISection[] => {
+  const lines = markdown.split(/\r?\n/);
+  const sections: ISection[] = [];
+  let currentHeading = pageTitle;
+  let buffer: string[] = [];
+
+  const flush = () => {
+    const content = buffer.join('\n').trim();
+    if (!content) {
+      return;
+    }
+
+    sections.push({
+      heading: currentHeading,
+      content,
+    });
+  };
+
+  lines.forEach((line) => {
+    const match = line.match(/^#{2,3}\s+(.+)$/);
+    if (match) {
+      flush();
+      currentHeading = match[1]?.trim() || pageTitle;
+      buffer = [currentHeading];
+      return;
+    }
+
+    buffer.push(line);
+  });
+
+  flush();
+
+  if (sections.length === 0) {
+    const content = markdown.trim();
+    if (content.length > 0) {
+      sections.push({
+        heading: pageTitle,
+        content,
+      });
+    }
+  }
+
+  return sections;
+};
+
+const flattenSectionsToTokens = (sections: ISection[]): ITokenWithHeading[] =>
+  sections.flatMap((section) =>
+    encode(section.content).map((tokenId) => ({
+      tokenId,
+      heading: section.heading,
+    })),
+  );
+
+const decodeTokens = (tokens: ITokenWithHeading[]): string =>
+  decode(tokens.map((token) => token.tokenId));
+
+const clampBatchSize = (batchSize?: number): number => {
+  if (!batchSize || Number.isNaN(batchSize)) {
+    return DEFAULT_BATCH_SIZE;
+  }
+
+  return Math.min(Math.max(1, Math.floor(batchSize)), DEFAULT_BATCH_SIZE);
+};
+
+const createEmbeddingClient = (apiKey: string): IEmbeddingClient => {
+  const openai = new OpenAI({ apiKey });
+
+  return {
+    embeddings: {
+      create: async ({ model, input }) => createEmbeddingsWithRetry(openai, model, input),
+    },
+  };
+};
+
+export const chunkWikiPages = (input: IChunkWikiPagesInput): IChunkedWikiSection[] => {
+  const minTokens = Math.max(1, Math.floor(input.minTokens ?? DEFAULT_MIN_TOKENS));
+  const maxTokens = Math.max(minTokens, Math.floor(input.maxTokens ?? DEFAULT_MAX_TOKENS));
+  const overlapTokens = Math.max(
+    0,
+    Math.min(maxTokens - 1, Math.floor(input.overlapTokens ?? DEFAULT_OVERLAP_TOKENS)),
+  );
+  const stride = Math.max(1, maxTokens - overlapTokens);
+
+  const chunks: IChunkedWikiSection[] = [];
+
+  input.pages.forEach((page) => {
+    const sections = extractSections(page.title, page.content);
+    const tokens = flattenSectionsToTokens(sections);
+
+    if (tokens.length === 0) {
+      return;
+    }
+
+    if (tokens.length <= maxTokens) {
+      const firstToken = tokens.at(0);
+
+      chunks.push({
+        pageId: page.pageId,
+        sectionHeading: firstToken ? firstToken.heading : page.title,
+        chunkText: decodeTokens(tokens),
+        chunkIndex: 0,
+        tokenCount: tokens.length,
+      });
+      return;
+    }
+
+    let start = 0;
+    let chunkIndex = 0;
+
+    while (start < tokens.length) {
+      const end = Math.min(tokens.length, start + maxTokens);
+      const window = tokens.slice(start, end);
+
+      if (window.length === 0) {
+        break;
+      }
+
+      if (window.length < minTokens && chunks.length > 0) {
+        const lastChunk = chunks[chunks.length - 1];
+        if (lastChunk?.pageId === page.pageId) {
+          const merged = `${lastChunk.chunkText}\n\n${decodeTokens(window)}`.trim();
+          lastChunk.chunkText = merged;
+          lastChunk.tokenCount += window.length;
+          break;
+        }
+      }
+
+      const firstWindowToken = window.at(0);
+
+      chunks.push({
+        pageId: page.pageId,
+        sectionHeading: firstWindowToken ? firstWindowToken.heading : page.title,
+        chunkText: decodeTokens(window),
+        chunkIndex,
+        tokenCount: window.length,
+      });
+
+      if (end >= tokens.length) {
+        break;
+      }
+
+      start += stride;
+      chunkIndex += 1;
+    }
+  });
+
+  return chunks;
+};
+
+export const embedChunks = async (
+  input: IEmbedChunksInput,
+  options?: { client?: IEmbeddingClient },
+): Promise<IEmbeddedWikiSection[]> => {
+  const chunks = chunkWikiPages(input);
+  if (chunks.length === 0) {
+    return [];
+  }
+
+  const model = input.model ?? 'text-embedding-3-small';
+  const apiKey = input.openaiApiKey ?? process.env['OPENAI_API_KEY'];
+  const client =
+    options?.client ??
+    (apiKey
+      ? createEmbeddingClient(apiKey)
+      : (() => {
+          throw new Error('OPENAI_API_KEY is required to generate wiki embeddings.');
+        })());
+
+  const batchSize = clampBatchSize(input.batchSize);
+  const embeddedChunks: IEmbeddedWikiSection[] = [];
+
+  for (let index = 0; index < chunks.length; index += batchSize) {
+    const batch = chunks.slice(index, index + batchSize);
+    const response = await client.embeddings.create({
+      model,
+      input: batch.map((chunk) => chunk.chunkText),
+    });
+
+    if (response.data.length !== batch.length) {
+      throw new Error(
+        `Embedding API response mismatch: expected ${batch.length} vectors, received ${response.data.length}.`,
+      );
+    }
+
+    batch.forEach((chunk, batchIndex) => {
+      const embedding = response.data[batchIndex]?.embedding;
+      if (!embedding) {
+        throw new Error(`Missing embedding vector for chunk index ${chunk.chunkIndex}.`);
+      }
+
+      embeddedChunks.push({
+        ...chunk,
+        embedding,
+      });
+    });
+  }
+
+  return embeddedChunks;
+};

--- a/packages/generator/src/embed-chunks.ts
+++ b/packages/generator/src/embed-chunks.ts
@@ -234,7 +234,8 @@ export const chunkWikiPages = (input: IChunkWikiPagesInput): IChunkedWikiSection
         if (lastChunk?.pageId === page.pageId) {
           const merged = `${lastChunk.chunkText}\n\n${decodeTokens(window)}`.trim();
           lastChunk.chunkText = merged;
-          lastChunk.tokenCount += window.length;
+          // Re-tokenize merged text so tokenCount stays accurate after separator + trim.
+          lastChunk.tokenCount = encode(merged).length;
           break;
         }
       }

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -2,3 +2,11 @@ export { generateWiki } from './generate';
 export type { GenerateOptions, GenerateInput } from './generate';
 export { streamWikiPage } from './stream';
 export type { StreamGenerateOptions } from './stream';
+export { chunkWikiPages, embedChunks } from './embed-chunks';
+export type {
+  IPageForEmbedding,
+  IChunkWikiPagesInput,
+  IChunkedWikiSection,
+  IEmbedChunksInput,
+  IEmbeddedWikiSection,
+} from './embed-chunks';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@wikismith/shared':
         specifier: workspace:*
         version: link:../shared
+      gpt-tokenizer:
+        specifier: ^3.4.0
+        version: 3.4.0
       openai:
         specifier: ^6.25.0
         version: 6.25.0(zod@4.3.6)
@@ -3005,6 +3008,9 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gpt-tokenizer@3.4.0:
+    resolution: {integrity: sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -6806,7 +6812,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.3(jiti@2.6.1))
@@ -6833,7 +6839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6848,14 +6854,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -6870,7 +6876,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7154,6 +7160,8 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  gpt-tokenizer@3.4.0: {}
 
   graceful-fs@4.2.11: {}
 


### PR DESCRIPTION
## Summary
- add a new `wiki_embeddings` pgvector table (1536 dims) with HNSW cosine index plus migration artifacts and DB helpers for transactional replace + similarity queries
- implement deterministic wiki page chunking by `##`/`###` headers (500-1000 token windows with overlap), batch embedding generation via `text-embedding-3-small`, and exported `embedChunks`/`chunkWikiPages` utilities
- integrate a non-blocking embedding pipeline into wiki persistence, including background execution, retry handling, missing-key warnings, and recovery when a wiki is loaded without embeddings
- add unit coverage for chunking/embedding behavior and background embedding pipeline behavior in `wiki-store`

## Validation
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `cubic review` (clean)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end embeddings pipeline for wiki pages with pgvector storage and fast similarity search, plus reliability and indexing improvements. Content is chunked deterministically, embedded in the background, and stored in a new wiki_embeddings table.

- New Features
  - New wiki_embeddings table (vector(1536)) with HNSW cosine index and btree indexes; replaceWikiEmbeddings and findSimilarWikiEmbeddings helpers.
  - Deterministic H2/H3 chunking (500–1000 tokens, 100-token overlap) using gpt-tokenizer; batch embeddings via text-embedding-3-small.
  - Non-blocking pipeline triggered on saveWiki with logging; auto-recovery on getWiki/getPublicWiki if embeddings are missing.
  - Unit tests for chunking/embedding, background pipeline behavior, and a test helper to await pending jobs.

- Bug Fixes
  - Added exponential backoff retries for OpenAI 429/5xx and clearer stderr logging; pipeline skips cleanly when OPENAI_API_KEY is missing.
  - Transactional embedding replace now uses an advisory lock, validates vectors, and caps similarity query limits for safety.

- Migration
  - Apply migration 0006 (creates pgvector extension and wiki_embeddings table/indexes).
  - Set OPENAI_API_KEY; without it, the pipeline is skipped with a warning.
  - No API changes; embedding runs in the background and does not block saves.

<sup>Written for commit 28afaa8997e52afcaafdb11728edc028a9c51a06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

